### PR TITLE
Add use-existing-release option to upload functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Flags:
       --release-name-template string   Go template for computing release names, using chart metadata (default "{{ .Name }}-{{ .Version }}")
       --release-notes-file string      Markdown file with chart release notes. If it is set to empty string, or the file is not found, the chart description will be used instead. The file is read from the chart package
       --skip-existing                  Skip upload if release exists
+      --use-existing-release           Add packages to existing release instead of creating new release
   -t, --token string                   GitHub Auth Token
       --make-release-latest bool       Mark the created GitHub release as 'latest' (default "true")
       --packages-with-index            Host the package files in the GitHub Pages branch

--- a/cr/cmd/upload.go
+++ b/cr/cmd/upload.go
@@ -52,6 +52,7 @@ func init() {
 	uploadCmd.Flags().StringP("git-upload-url", "u", "https://uploads.github.com/", "GitHub Upload URL (only needed for private GitHub)")
 	uploadCmd.Flags().StringP("commit", "c", "", "Target commit for release")
 	uploadCmd.Flags().Bool("skip-existing", false, "Skip upload if release exists")
+	uploadCmd.Flags().Bool("use-existing-release", false, "Add packages to existing release instead of creating new release")
 	uploadCmd.Flags().String("release-name-template", "{{ .Name }}-{{ .Version }}", "Go template for computing release names, using chart metadata")
 	uploadCmd.Flags().String("release-notes-file", "", "Markdown file with chart release notes. "+
 		"If it is set to empty string, or the file is not found, the chart description will be used instead. The file is read from the chart package")

--- a/doc/cr_upload.md
+++ b/doc/cr_upload.md
@@ -31,6 +31,7 @@ cr upload [flags]
       --remote string                  The Git remote used when creating a local worktree for the GitHub Pages branch (default "origin")
       --skip-existing                  Skip upload if release exists
   -t, --token string                   GitHub Auth Token
+      --use-existing-release           Add packages to existing release instead of creating new release
 ```
 
 ### Options inherited from parent commands

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -58,6 +58,7 @@ type Options struct {
 	Remote               string `mapstructure:"remote"`
 	ReleaseNameTemplate  string `mapstructure:"release-name-template"`
 	SkipExisting         bool   `mapstructure:"skip-existing"`
+	UseExistingRelease   bool   `mapstructure:"use-existing-release"`
 	ReleaseNotesFile     string `mapstructure:"release-notes-file"`
 	GenerateReleaseNotes bool   `mapstructure:"generate-release-notes"`
 	MakeReleaseLatest    bool   `mapstructure:"make-release-latest"`

--- a/pkg/releaser/releaser.go
+++ b/pkg/releaser/releaser.go
@@ -49,6 +49,7 @@ import (
 // objects
 type GitHub interface {
 	CreateRelease(ctx context.Context, input *github.Release) error
+	AddAssetsToRelease(ctx context.Context, tag string, assets []*github.Asset) error
 	GetRelease(ctx context.Context, tag string) (*github.Release, error)
 	CreatePullRequest(owner string, repo string, message string, head string, base string) (string, error)
 }
@@ -341,8 +342,15 @@ func (r *Releaser) CreateReleases() error {
 				continue
 			}
 		}
-		if err := r.github.CreateRelease(context.TODO(), release); err != nil {
-			return errors.Wrapf(err, "error creating GitHub release %s", releaseName)
+
+		if r.config.UseExistingRelease {
+			if err := r.github.AddAssetsToRelease(context.TODO(), releaseName, release.Assets); err != nil {
+				return errors.Wrapf(err, "error adding assets to GitHub release %s", releaseName)
+			}
+		} else {
+			if err := r.github.CreateRelease(context.TODO(), release); err != nil {
+				return errors.Wrapf(err, "error creating GitHub release %s", releaseName)
+			}
 		}
 
 		if r.config.PackagesWithIndex {

--- a/pkg/releaser/releaser_test.go
+++ b/pkg/releaser/releaser_test.go
@@ -92,6 +92,11 @@ func (f *FakeGitHub) CreateRelease(ctx context.Context, input *github.Release) e
 	return nil
 }
 
+func (f *FakeGitHub) AddAssetsToRelease(ctx context.Context, releaseName string, assets []*github.Asset) error {
+	f.Called(ctx, releaseName, assets)
+	return nil
+}
+
 func (f *FakeGitHub) GetRelease(ctx context.Context, tag string) (*github.Release, error) { //nolint: revive
 	release := &github.Release{
 		Name:        "testdata/release-packages/test-chart-0.1.0",


### PR DESCRIPTION
This makes it possible to add the release packages to an existing release instead of creating a new release. This is useful when a release is used to trigger the helm package and upload.